### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/goreleaser-check.yml
+++ b/.github/workflows/goreleaser-check.yml
@@ -9,6 +9,8 @@ on:
       - 'go.mod'
       - 'go.sum'
 
+permissions:
+  contents: read
 jobs:
   goreleaser-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/trly/quad-ops/security/code-scanning/3](https://github.com/trly/quad-ops/security/code-scanning/3)

To fix the problem, you should add a `permissions:` key to the workflow, ideally at the top level so that it applies to all jobs. This will explicitly restrict the permissions granted to the `GITHUB_TOKEN`, following the principle of least privilege. For most workflows that check code, build, run tests, or do analysis without making repository changes, the minimal safe value is `contents: read`. If you know certain steps require additional write permissions (for example, if they create issues or update pull requests), you can grant those granularly at the job level instead. In this workflow, none of the steps appear to require write access, so setting `contents: read` at the workflow level is suitable.

Insert the following block:

```yaml
permissions:
  contents: read
```

above the `jobs:` key, right after the `on:` block (after line 11).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
